### PR TITLE
Fix Makefile Go module base path detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ SHELL = /bin/bash
 WHAT					= ntpt
 
 # What package holds the "version" variable used in branding/version output?
-#VERSION_VAR_PKG			= $(shell go list .)/config
+#VERSION_VAR_PKG			= $(shell go list -m)/config
 VERSION_VAR_PKG			= main
 
 OUTPUTDIR 				= release_assets


### PR DESCRIPTION
Replace `go list .` with `go list -m` to reflect that most projects now no longer contain a doc.go file in the project root.

NOTE: This set of changes does not directly impact the tool provided by this project as it does not emit version output, but rather updates the VERSION_VAR_PKG var in case the tool is updated in the future to include this info.

refs https://github.com/atc0005/todo/issues/46