### PR TITLE
Update development branch to specific Go release

### DIFF
--- a/dependabot/docker/go/Dockerfile
+++ b/dependabot/docker/go/Dockerfile
@@ -15,4 +15,4 @@
 # binaries) to reflect that version of Go.
 
 # https://hub.docker.com/_/golang
-FROM golang:1.21
+FROM golang:1.21.0


### PR DESCRIPTION
Switch from golang:1.21 version series to 1.21.0 release. This is one
version back from the very latest release in that series to confirm
that the Dependabot monitoring configuration for this branch's canary
file is setup correctly.
