### PR TITLE
Fix errcheck linting errors

### DIFF
--- a/cmd/ntpt/main.go
+++ b/cmd/ntpt/main.go
@@ -49,7 +49,7 @@ type config struct {
 
 // Branding is responsible for emitting application name, version and origin
 func Branding() {
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		flag.CommandLine.Output(),
 		"\n%s %s\n%s\n\n",
 		myAppName,
@@ -67,7 +67,7 @@ func flagsUsage() func() {
 
 		Branding()
 
-		fmt.Fprintf(flag.CommandLine.Output(), "Usage of \"%s\":\n",
+		_, _ = fmt.Fprintf(flag.CommandLine.Output(), "Usage of \"%s\":\n",
 			myBinaryName,
 		)
 		flag.PrintDefaults()


### PR DESCRIPTION
Resolve `return value of fmt.Fprintf is not checked`` errors by
explicitly discarding return values (potential error, bytes written)
since we do not need them and the potential for failure (in this
particular use case) is *highly* unlikely.
